### PR TITLE
fixed bug 

### DIFF
--- a/backend/routes/api/spots.js
+++ b/backend/routes/api/spots.js
@@ -12,8 +12,9 @@ router.get('/', async (req, res, next) => {
     include: [
       {
         model: SpotImage,
-        attributes: [['url', 'previewImage']],
-        where: { preview: true }
+        attributes: ['url'],
+        where: { preview: true },
+        required: false
       },
       {
         model: Review,
@@ -30,12 +31,19 @@ router.get('/', async (req, res, next) => {
     // extract aggregate key
     const { Reviews, SpotImages } = spotJSON;
     // calculate average rating
-    spotJSON.avgRating = Reviews.reduce((acc, ele) => { return acc + ele.stars }, 0) / Reviews.length;
-    spotJSON.previewImage = SpotImages[0].previewImage;
-    // delete the unwanted key
+    if (Reviews.length) {
+      spotJSON.avgRating = Reviews.reduce((acc, ele) => { return acc + ele.stars }, 0) / Reviews.length;
+    } else {
+      spotJSON.avgRating = null;
+    }
+    // find preview
+    if (SpotImages.length) {
+      spotJSON.previewImage = SpotImages[0].url;
+    } else {
+      spotJSON.previewImage = null;
+    }
     delete spotJSON["Reviews"];
     delete spotJSON["SpotImages"];
-    // return single element to the array
     return spotJSON;
   });
 
@@ -58,7 +66,8 @@ router.get('/current', async (req, res, next) => {
       {
         model: SpotImage,
         attributes: [['url', 'previewImage']],
-        where: { preview: true }
+        where: { preview: true },
+        required: false
       },
       {
         model: Review,
@@ -70,17 +79,23 @@ router.get('/current', async (req, res, next) => {
   const resObj = {};
 
   resObj.Spots = spots.map(spot => {
-    // convert to JSON object
     const spotJSON = spot.toJSON();
     // extract aggregate key
     const { Reviews, SpotImages } = spotJSON;
     // calculate average rating
-    spotJSON.avgRating = Reviews.reduce((acc, ele) => { return acc + ele.stars }, 0) / Reviews.length;
-    spotJSON.previewImage = SpotImages[0].previewImage;
-    // delete the unwanted key
+    if (Reviews.length) {
+      spotJSON.avgRating = Reviews.reduce((acc, ele) => { return acc + ele.stars }, 0) / Reviews.length;
+    } else {
+      spotJSON.avgRating = null;
+    }
+    // find preview
+    if (SpotImages.length) {
+      spotJSON.previewImage = SpotImages[0].url;
+    } else {
+      spotJSON.previewImage = null;
+    }
     delete spotJSON["Reviews"];
     delete spotJSON["SpotImages"];
-    // return single element to the array
     return spotJSON;
   });
 


### PR DESCRIPTION
When using eager loading with where clause, added required: false to the query option object.

Add the "where clause" to the  "include" object with apply the "where clause" to both "main query" and "eager loading query." Adding "required: false" will limit the "where clause" applies only to the "eager loading query."